### PR TITLE
Add missing requirement "packaging"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ocrd >= 2.23.2
 lxml
 langcodes[data] >= 3.1.0
+packaging


### PR DESCRIPTION
page-to-alto failed for me in a fresh Python 3.9 virtualenv:

~~~
% page-to-alto
Traceback (most recent call last):
  File "/home/mike/.virtualenvs/tmp.87645/bin/page-to-alto", line 33, in <module>
    sys.exit(load_entry_point('ocrd-page-to-alto', 'console_scripts', 'page-to-alto')())
  File "/home/mike/.virtualenvs/tmp.87645/bin/page-to-alto", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib64/python3.9/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib64/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/mike/devel/page-to-alto/ocrd_page_to_alto/cli.py", line 2, in <module>
    from .convert import OcrdPageAltoConverter
  File "/home/mike/devel/page-to-alto/ocrd_page_to_alto/convert.py", line 3, in <module>
    from packaging import version
ModuleNotFoundError: No module named 'packaging'
~~~

Fix this by adding `packaging` to `requirements.txt`.