### PR TITLE
output Created/LastChange timestamp as processingDateTime, fix #36

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 executors:
-  ubuntu1804:
+  ubuntu2204:
     docker:
-      - image: ubuntu:18.04
+      - image: ubuntu:22.04
 
 commands:
   install-test:
@@ -23,7 +23,7 @@ commands:
 jobs:
 
   build-python:
-    executor: ubuntu1804
+    executor: ubuntu2204
     parameters:
       python-version:
         type: string
@@ -38,7 +38,8 @@ workflows:
           matrix:
             parameters:
               python-version:
-                - '3.6'
                 - '3.7'
                 - '3.8'
                 - '3.9'
+                - '3.10'
+                - '3.11'

--- a/ocrd_page_to_alto/cli.py
+++ b/ocrd_page_to_alto/cli.py
@@ -21,11 +21,12 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               "'first' will use the first TextEquiv, 'last' will use the last TextEquiv on the element")
 @click.option('--region-order', default='document', help="Order in which to iterate over the regions", type=click.Choice(['document', 'reading-order', 'reading-order-only']))
 @click.option('--textline-order', default='document', help="Order in which to iterate over the textlines", type=click.Choice(['document', 'index', 'textline-order']))
+@click.option('--timestamp-src', default='LastChange', help="Which element to use for the timestamp", type=click.Choice(['Created', 'LastChange', 'none']))
 @click.option('-O', '--output-file', default='-', help='Output filename (or "-" for standard output, the default)',
               type=click.Path(dir_okay=False, writable=True, exists=False, allow_dash=True))
 @click.argument('filename',  type=click.Path(dir_okay=False, exists=True))
 def main(log_level, alto_version, check_words, check_border, skip_empty_lines, trailing_dash_to_hyp, dummy_textline, dummy_word, 
-         textequiv_index, textequiv_fallback_strategy, region_order, textline_order, output_file, filename):
+         textequiv_index, textequiv_fallback_strategy, region_order, textline_order, timestamp_src, output_file, filename):
     """
     Convert PAGE to ALTO
     """
@@ -34,6 +35,7 @@ def main(log_level, alto_version, check_words, check_border, skip_empty_lines, t
         alto_version=alto_version,
         page_filename=filename,
         check_words=check_words,
+        timestamp_src=timestamp_src,
         check_border=check_border,
         skip_empty_lines=skip_empty_lines,
         trailing_dash_to_hyp=trailing_dash_to_hyp,

--- a/ocrd_page_to_alto/convert.py
+++ b/ocrd_page_to_alto/convert.py
@@ -277,7 +277,6 @@ class OcrdPageAltoConverter():
                     json[label.get_type()] = label.value
                 step_alto_settings.text = dumps(json)
             if self.timestamp_src:
-                print(page_timestamp)
                 step_alto_processing_date_time = ET.SubElement(step_alto, 'processingDateTime')
                 step_alto_processing_date_time.text = page_timestamp.isoformat()
             step_alto_software = ET.SubElement(step_alto, 'processingSoftware')

--- a/tests/data/timestamp.page.xml
+++ b/tests/data/timestamp.page.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pc:PcGts xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15/pagecontent.xsd" pcGtsId="OCR-D-OCR-CALAMARI_00001">
+    <pc:Metadata>
+        <pc:Creator>OCR-D</pc:Creator>
+        <pc:Created>2016-09-20T11:09:27.041000+02:00</pc:Created>
+        <pc:LastChange>2018-04-25T17:44:49.605000+01:00</pc:LastChange>
+        <pc:MetadataItem type="processingStep" name="preprocessing/optimization/binarization" value="ocrd-olena-binarize">
+            <pc:Labels>
+                <pc:Label value="sauvola-ms-split" type="impl"/>
+                <pc:Label value="0.34" type="k"/>
+                <pc:Label value="0" type="win-size"/>
+                <pc:Label value="0" type="dpi"/>
+            </pc:Labels>
+        </pc:MetadataItem>
+    </pc:Metadata>
+    <pc:Page imageFilename="OCR-D-IMG/044417.jpg" imageWidth="3195" imageHeight="4370" type="content" primaryLanguage="Welsh" secondaryLanguage="Urdu" primaryScript="Avst - Avestan" secondaryScript="Cans - Unified Canadian Aboriginal Syllabics">
+        <pc:Border>
+            <pc:Coords points="61,254 2770,254 2770,4360 61,4360"/>
+        </pc:Border>
+        <pc:TextRegion id="r1" primaryLanguage="Volapük" secondaryLanguage="Interlingua" primaryScript="Cham - Cham" secondaryScript="Buhd - Buhid">
+            <pc:Coords points="0,0 1,1 1,0 0,1"/>
+            <pc:TextLine id="r1-l1" primaryLanguage="Norwegian Bokmål">
+                <pc:Coords points="0,0 1,1 1,0 0,1"/>
+                <pc:Word id="r1-l1-w1" language="Esperanto">
+                    <pc:Coords points="0,0 1,1 1,0 0,1"/>
+                    <pc:TextEquiv>
+                        <pc:Unicode>patrofikulo</pc:Unicode>
+                    </pc:TextEquiv>
+                </pc:Word>
+                <pc:TextEquiv>
+                    <pc:Unicode>patrofikulo</pc:Unicode>
+                </pc:TextEquiv>
+            </pc:TextLine>
+        </pc:TextRegion>
+    </pc:Page>
+</pc:PcGts>

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,5 +1,6 @@
 from pytest import raises, main, fixture
 from lxml import etree as ET
+from datetime import datetime
 
 from ocrd_page_to_alto.convert import OcrdPageAltoConverter, NAMESPACES as _NAMESPACES
 from ocrd_utils import initLogging
@@ -110,6 +111,29 @@ def test_reading_order():
     assert len(tree.xpath('//alto:PrintSpace/alto:TextBlock', namespaces=NAMESPACES)) == 2
     assert tree.xpath('//alto:TextBlock[1]', namespaces=NAMESPACES)[0].get('ID') == 'region_0003'
 
+def test_convert_timestamp():
+    ts = datetime.fromisoformat
+
+    last_changed = ts('2018-04-25T17:44:49.605+01:00')
+    tree = ET.fromstring(str(OcrdPageAltoConverter(
+        page_filename='tests/data/timestamp.page.xml',
+        timestamp_src='LastChange',
+    ).convert()).encode('utf-8'))
+    assert ts(tree.xpath('//alto:processingDateTime/text()', namespaces=NAMESPACES)[0]) == last_changed
+
+    created = ts('2016-09-20T11:09:27.041+02:00')
+    tree = ET.fromstring(str(OcrdPageAltoConverter(
+        page_filename='tests/data/timestamp.page.xml',
+        timestamp_src='Created',
+    ).convert()).encode('utf-8'))
+    assert ts(tree.xpath('//alto:processingDateTime/text()', namespaces=NAMESPACES)[0]) == created
+
+    tree = ET.fromstring(str(OcrdPageAltoConverter(
+        page_filename='tests/data/timestamp.page.xml',
+        timestamp_src='none',
+    ).convert()).encode('utf-8'))
+    with raises(IndexError):
+        assert tree.xpath('//alto:processingDateTime/text()', namespaces=NAMESPACES)[0]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With this PR, the `alto:processingDateTime` element of an `alto:processingStep` will be set to either the `pc:Created` timestamp (`--timestamp-src Created`), the `pc:LastChange` timestamp (`--timestamp-src LastChange`) or not at all like before (`--timestamp-src none`).

This is not 100% correct since `Created` and `LastChange` are document-wide and not step-specific but we have no other source for them AFAICS and it is important for our (@StaatsbibliothekBerlin) workflows to have at least an approximate date for versioning purposes in the `alto:processingStep`s.